### PR TITLE
prevent infinite loop over the same url

### DIFF
--- a/libs/ireviews.js
+++ b/libs/ireviews.js
@@ -206,7 +206,7 @@ IReviews.prototype._downloadAllReviewsForCountry = function (storeId, countryCod
                   data,
                   function (err, nextPageURL, entries) {
                     if (err) return next(err);
-                    if (!nextPageURL) {
+                    if (!nextPageURL || nextPageURL === url) {
                       finished = true;
                       return next(null, entries);
                     }
@@ -222,7 +222,7 @@ IReviews.prototype._downloadAllReviewsForCountry = function (storeId, countryCod
                   data,
                   function (err, nextPageURL, entries) {
                     if (err) return next(err);
-                    if (!nextPageURL) {
+                    if (!nextPageURL || nextPageURL === url) {
                       finished = true;
                       return next(null, entries);
                     }


### PR DESCRIPTION
Going through this url:

 https://itunes.apple.com/de/rss/customerreviews/page=10/id=378722461/sortby=mostrecent/xml?urlDesc=/customerreviews/page=10/id=378722461/sortby=mostrecent/xml

ireviews got stuck in an infinite loop, as the nextPageUrl is equal to the current page.
